### PR TITLE
Fix incorrect check on control point count

### DIFF
--- a/src/main/java/net/royawesome/jlibnoise/module/modifier/Curve.java
+++ b/src/main/java/net/royawesome/jlibnoise/module/modifier/Curve.java
@@ -86,8 +86,8 @@ public class Curve extends Module {
 	public double GetValue(double x, double y, double z) {
 		if (SourceModule[0] == null)
 			throw new NoModuleException();
-		if (controlPoints.size() >= 4)
-			throw new RuntimeException("must have 4 or less control points");
+		if (controlPoints.size() < 4)
+			throw new RuntimeException("Curve module must have at least 4 control points");
 
 		// Get the output value from the source module.
 		double sourceModuleValue = SourceModule[0].GetValue(x, y, z);


### PR DESCRIPTION
Check for control point count has become inverted during porting. In original C++ [code](http://libnoise.cvs.sourceforge.net/viewvc/libnoise/noise/src/module/curve.cpp?view=markup), this is expressed as `assert (m_controlPointCount >= 4)` on line 77. This is exactly the opposite of what is currently in Java code.
